### PR TITLE
Typo: Removed an extra grammatical article

### DIFF
--- a/content/02-getting-started/01-installing-the-cardano-node.mdx
+++ b/content/02-getting-started/01-installing-the-cardano-node.mdx
@@ -7,7 +7,7 @@ You can install the Cardano node using
 [pre-compiled executable files](https://github.com/input-output-hk/cardano-node#linux-executable)
 for your platform.
 
-Alternatively, if you want to build the from source, there are two options
+Alternatively, if you want to build from source, there are two options
 available to you. Depending on your build tool preference, you can build from
 the source code using either of the following:
 


### PR DESCRIPTION
Removed an extra (and wrongly placed) grammatical article on the "build from source" phrase. Previously it said "build the from source".