### PR TITLE
remove duplicate paragraph

### DIFF
--- a/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
+++ b/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
@@ -17,11 +17,6 @@ conceptual difference between these two roles:
    
 Usually, the stake pool operator and the owner is the same person, however, a stake pool can also have multiple owners, who pledge their stake to form one larger pool to ensure it is competitive. Even in this case, there is still only one stake pool operator who is responsible for stake pool processes.
 
-Usually, the stake pool operator and the owner is the same person, however, a
-stake pool can also have multiple owners, who pledge their stake to form one
-larger pool to ensure it is competitive. Even in this case, there is still only
-one stake pool operator who is responsible for stake pool processes.
-
 It is essential that all stake pool owners trust a stake pool operator. All
 operators’ and owners’ rewards are paid out into a single shared reward account
 associated with the reward address of the pool, and are distributed by the


### PR DESCRIPTION
> Usually, the stake pool operator and the owner is the same person, however, a stake pool can also have multiple owners, who pledge their stake to form one larger pool to ensure it is competitive. Even in this case, there is still only one stake pool operator who is responsible for stake pool processes.

occurs twice in a row in the `about-stake-pools` documentation 