### PR TITLE
Update developer/support links

### DIFF
--- a/content/11-community/05-getting-support.mdx
+++ b/content/11-community/05-getting-support.mdx
@@ -14,10 +14,15 @@ it to the sections on this website. Please remember to check back regularly.
 
 # Telegram Channel: Cardano Developers
 
-You can reach the developers of Cardano directly on the Telegram website. Just
-join the
-[@CardanoStakePoolWorkgroup channel](https://t.me/CardanoStakePoolWorkgroup).
+You can reach the developers in Cardano community using links below:
+- [Cardano Forums](https://forum.cardano.org/c/developers/)
+- [Stack Exchange](https://cardano.stackexchange.com/)
+- Telegram:
+  - [Group for Development queries](https://t.me/CardanoDevelopers)
+  - [Group for Stake Pool Operation queries](https://t.me/CardanoStakePoolWorkgroup).
 
 # Where can I get technical support?
 
 To contact IOHK Technical Support, please submit a request using the [Submit a request form](https://iohk.zendesk.com/hc/en-us/requests/new). On that page you can also click the Support button at the bottom right of your screen. The request form is better if you have a lot to write.
+
+To use Community Technical Support, you can visit [Cardano Forums](https://forum.cardano.org/c/english/communitytechnicalsupport) , [Stack Exchange](https://cardano.stackexchange.com/) or [Telegram channel](https://t.me/CardanoCommunityTechSupport).


### PR DESCRIPTION
Links should include wider community beyond IOG themselves, unless hosting docs.iohk.* 😉 