### PR TITLE
Remove duplicate question

### DIFF
--- a/content/04-core-concepts/06-pledging-and-delegation-options.mdx
+++ b/content/04-core-concepts/06-pledging-and-delegation-options.mdx
@@ -80,34 +80,30 @@ party.
    **A**: Please review the steps in the documentation
    [here.](https://github.com/input-output-hk/cardano-node/blob/master/doc/stake-pool-operations/getConfigFiles_AND_Connect.md)
 
-2. **Q: How do I generate staking addresses?**
+1. **Q: How do I generate staking addresses?**
 
    **A**: Please review the steps in the documentation
    [here.](https://github.com/input-output-hk/cardano-node/blob/master/doc/stake-pool-operations/register_key.md)
 
-3. **Q: How do I determine an optimal amount of ada to pledge to each pool?**
+1. **Q: How do I determine an optimal amount of ada to pledge to each pool?**
 
    **A**: This is a personal preference, the more you pledge the higher the
    rewards.
 
-4. **Q: How do I know if my pool is oversaturated?**
+1. **Q: How do I know if my pool is oversaturated?**
 
    **A**: If the amount of ada delegated to the pool is over 32 million, the
    pool is oversaturated.
 
-5. **Q: How do I know who has delegated to my pool?**
+1. **Q: How do I know who has delegated to my pool?**
 
    **A**: You can query the ledger state.
 
-6. **Q: How do I know who has delegated to my pool?**
-
-   **A**: You can query the ledger state.
-
-7. **Q: How can I calculate rewards?**
+1. **Q: How can I calculate rewards?**
 
    **A**: This is calculated automatically by the Ouroboros protocol.
 
-8. **Q: How can I verify whether my pool was successfully registered on
+1. **Q: How can I verify whether my pool was successfully registered on
    mainnet?**
 
    **A**: You can check [pooltool.io](https://pooltool.io/) or run the following


### PR DESCRIPTION
* Removing a duplicated question from the FAQ section.
* Use `1.` for each list item so that order doesn't need to be maintained manually in the source.