### PR TITLE
Ambiguous description of rewards distribution

### DIFF
--- a/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
+++ b/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
@@ -19,10 +19,7 @@ Usually, the stake pool operator and the owner is the same person, however, a st
 
 It is essential that all stake pool owners trust a stake pool operator. All
 operators’ and owners’ rewards are paid out into a single shared reward account
-associated with the reward address of the pool, and **NOT** distributed by the
-protocol amongst the owner accounts. The reason for this is that otherwise,
-everyone could choose to become a co-owner of a stake pool instead of
-delegating, which would render the mechanism of pledging stake ineffective.
+associated with the reward address of the pool. The holder of the rewards account pays out rewards independently to the owners. 
 
 This makes it clear to all parties that an agreement is needed to define when
 and how the accumulated rewards in a shared account should be split. For

--- a/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
+++ b/content/02-getting-started/03-operating-a-stake-pool/01-about-stake-pools.mdx
@@ -19,7 +19,7 @@ Usually, the stake pool operator and the owner is the same person, however, a st
 
 It is essential that all stake pool owners trust a stake pool operator. All
 operators’ and owners’ rewards are paid out into a single shared reward account
-associated with the reward address of the pool, and are distributed by the
+associated with the reward address of the pool, and **NOT** distributed by the
 protocol amongst the owner accounts. The reason for this is that otherwise,
 everyone could choose to become a co-owner of a stake pool instead of
 delegating, which would render the mechanism of pledging stake ineffective.


### PR DESCRIPTION
The second part of the description regarding rewards distribution among pool owners sounds ambiguous ('are distributed').