### PR TITLE
Updates developers telegram group link

### DIFF
--- a/content/11-community/05-getting-support.mdx
+++ b/content/11-community/05-getting-support.mdx
@@ -18,7 +18,7 @@ You can reach the developers in Cardano community using links below:
 - [Cardano Forums](https://forum.cardano.org/c/developers/)
 - [Stack Exchange](https://cardano.stackexchange.com/)
 - Telegram:
-  - [Group for Development queries](https://t.me/CardanoDevelopers)
+  - [Group for Development queries](https://t.me/CardanoDevelopersOfficial)
   - [Group for Stake Pool Operation queries](https://t.me/CardanoStakePoolWorkgroup).
 
 # Where can I get technical support?


### PR DESCRIPTION
The developers telegram group link at [Getting Support](https://docs.cardano.org/community/getting-support) page was pointing to _Cardano Developers_ group, instead of the official one called _Cardano Developers Official_.