### PR TITLE
Correction for stability window constants

### DIFF
--- a/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
+++ b/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
@@ -11,7 +11,8 @@ When discussing [Cardano](https://cardano.org/), often-repeated questions are *w
 
 This is *the point beyond which the chain is guaranteed by protocol not to alter any further because of randomness, or random events.*
 
-Chain confirmation occurs at some point in the future, after a certain amount of future k blocks have been minted. The time between now and the point when chain confirmation for a particular transaction occurs is called the *stability window* (that is, the number of slots required for a block to become **stable**, where *stable* is defined as a block that cannot be rolled back). The formula to calculate this window is 3k/f (where k is the parameter that limits a pool's growth by decreasing its [rewards](https://docs.cardano.org/core-concepts/pledging-rewards) yield beyond a certain threshold, and f is the parameter that defines a pool's maximum reward yield.)
+Chain confirmation occurs at some point in the future, after a certain amount of future k blocks have been minted. The time between now and the point when chain confirmation for a particular transaction occurs is called the *stability window* (that is, the number of slots required for a block to become **sta![image](https://user-images.githubusercontent.com/3169068/135933527-c569db27-0d13-4c8a-856e-226f88fa405e.png)
+ble**, where *stable* is defined as a block that cannot be rolled back). The formula to calculate this window is 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter in genesis that determines the probability for amount of blocks created in an epoch.)
 
 **Transaction confirmation**
 

--- a/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
+++ b/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
@@ -9,7 +9,7 @@ When discussing [Cardano](https://cardano.org/), often-repeated questions are *w
 
 **Chain confirmation**
 
-This is *the point beyond which the chain is guaranteed by protocol not to alter any further because of randomness, or random events.*
+This is *the point beyond which the chain is guaranteed by the protocol not to alter any further because of randomness, or random events.*
 
 Chain confirmation occurs at some point in the future, after a certain amount of future k blocks have been minted. The time between now and the point when chain confirmation for a particular transaction occurs is called the *stability window* (that is, the number of slots required for a block to become **stable**, where *stable* is defined as a block that cannot be rolled back). The formula to calculate this window is 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter in genesis that determines the probability for amount of blocks created in an epoch.)
 

--- a/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
+++ b/content/04-core-concepts/11-chain-confirmation-versus-transaction-confirmation.mdx
@@ -11,8 +11,7 @@ When discussing [Cardano](https://cardano.org/), often-repeated questions are *w
 
 This is *the point beyond which the chain is guaranteed by protocol not to alter any further because of randomness, or random events.*
 
-Chain confirmation occurs at some point in the future, after a certain amount of future k blocks have been minted. The time between now and the point when chain confirmation for a particular transaction occurs is called the *stability window* (that is, the number of slots required for a block to become **sta![image](https://user-images.githubusercontent.com/3169068/135933527-c569db27-0d13-4c8a-856e-226f88fa405e.png)
-ble**, where *stable* is defined as a block that cannot be rolled back). The formula to calculate this window is 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter in genesis that determines the probability for amount of blocks created in an epoch.)
+Chain confirmation occurs at some point in the future, after a certain amount of future k blocks have been minted. The time between now and the point when chain confirmation for a particular transaction occurs is called the *stability window* (that is, the number of slots required for a block to become **stable**, where *stable* is defined as a block that cannot be rolled back). The formula to calculate this window is 3k/f (where k is the security parameter in genesis, and f is the active slot co-efficient parameter in genesis that determines the probability for amount of blocks created in an epoch.)
 
 **Transaction confirmation**
 


### PR DESCRIPTION
The variables `k` and `f` for stability window have nothing to do with Shelley reward parameters, the author may have confused `nOpt` which was commonly called `k` by some.