### PR TITLE
mention port mapping when using docker

### DIFF
--- a/content/02-getting-started/01-installing-the-cardano-node.mdx
+++ b/content/02-getting-started/01-installing-the-cardano-node.mdx
@@ -49,7 +49,7 @@ docker volume create cardano-node-ipc
 
 1. Run a passive node that is connected to the correct network. For example, for a `mainnet` node:
 
-``docker run -e NETWORK=mainnet -v cardano-node-ipc:/ipc -v cardano-node-data:/data inputoutput/cardano-node``
+``docker run -e NETWORK=mainnet -v cardano-node-ipc:/ipc -v cardano-node-data:/data -p 3001:3001 inputoutput/cardano-node``
 
 This creates a persistent docker environment for the node, where `/ipc` in the Docker container is connected to the logical `cardano-node-ipc` volume, and `/data` is connected to the `cardano-node-data` volume.  Note that you should change `NETWORK=mainnet` if you are connecting to a different network (eg a testnet).  
 


### PR DESCRIPTION
Docker won't publish ports as per default. So mentioning a port mapping would help users to not forget this portion and not confuse later why their nodes cannot connect owing to connection refuse while firewall allows it.