### PR TITLE
Lower the recommended MaxConcurrencyDeadline

### DIFF
--- a/content/02-getting-started/04-guidelines-for-large-spos.mdx
+++ b/content/02-getting-started/04-guidelines-for-large-spos.mdx
@@ -237,7 +237,7 @@ _Please note that IOHK relay nodes are outlined as examples._
 The `MaxConcurrencyDeadline` configuration option controls how many attempts the
 node will run in parallel to fetch the same block. Considering that getting the
 same block as soon as possible is important for both relay nodes and block
-producer nodes, we recommend setting the MaxConcurrencyDeadline value to 8.
+producer nodes, we recommend setting the MaxConcurrencyDeadline value to 4.
 
 ### Delegation and pledging advice
 


### PR DESCRIPTION
Lower the recommended MaxConcurrencyDeadline from 8 to 4. The node may
go over MaxConcurrencyDeadline, based on deltaq meassurements. This
means that a MaxConcurrencyDeadline of 4 is enough.