### PR TITLE
Pinning nixpkgs with fetchTarball

### DIFF
--- a/content/10-plutus/06-Plutus-transactions.mdx
+++ b/content/10-plutus/06-Plutus-transactions.mdx
@@ -99,7 +99,7 @@ Create a file in the root of the git repository we just cloned and save it as `p
 
 
 ```
-{ version ? "mainnet", pkgs ? import <nixpkgs> { }}:
+{ version ? "mainnet", pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/6525bbc06a39f26750ad8ee0d40000ddfdc24acb.tar.gz") { }}:
 let
   cardano-node-repo = import ./. { };
 


### PR DESCRIPTION
Make the environment for the tutorial reproducible. This fixes issues like this, that some users have reported.

```
"nix-shell plutus-tutorial.nix" I get:
error: attribute 'ghc8104' missing

       at /home/ubuntu/cardano-node/plutus-tutorial.nix:10:5:

            9|     zlib
           10|     haskell.compiler.ghc8104
             |     ^
           11|     haskellPackages.haskell-language-server
(use '--show-trace' to show detailed location information) 
```