### PR TITLE
Fix the statement with the correct amount

### DIFF
--- a/content/10-plutus/06-Plutus-transactions.mdx
+++ b/content/10-plutus/06-Plutus-transactions.mdx
@@ -343,7 +343,7 @@ cardano-cli transaction submit --tx-file tx.signed --mainnet
 Transaction successfully submitted.
 ```
 
-Now if we query payment2.addr we will have a new UTxO containing 30,000 ADAs:
+Now if we query payment2.addr we will have a new UTxO containing 500 ADAs:
 ```
 cardano-cli query utxo --address $(cat payment2.addr) --mainnet
 ```

--- a/content/10-plutus/07-datums-redeemers.mdx
+++ b/content/10-plutus/07-datums-redeemers.mdx
@@ -136,7 +136,7 @@ As it is an Alonzo-era transaction, we need to specify the `--alonzo-era` flag.
 You can find steps on how to create a transaction on the Alonzo era network in the Plutus transactions using cardano-cli.  
 
 ### Querying the script address
-The UTXO at this script address should now have 8 ada and the datum hash attached. To query it, run:
+The UTXO at this script address should now have 20 ada and the datum hash attached. To query it, run:
 
 ```
 $ cardano-cli query utxo --address $(cat datum-redeemer.addr) --mainnet
@@ -229,7 +229,7 @@ Transaction successfully submitted.
 ```
 
 ### Querying both payment and script addresses
-We can query the addresses to ensure that we have unlocked the funds. There is now no UTXO at the script address and a new one with 8 ada has been received.:
+We can query the addresses to ensure that we have unlocked the funds. There is no UTXO at the script address, and a new one with the adas received.:
 
 ```
 $ cardano-cli query utxo --address $(cat datum-redeemer.addr) --mainnet


### PR DESCRIPTION
As it wrongly states that after a transaction from wallet 1 to wallet 2 sending 500.000.000 Lovelace (500 ADA) that wallet 2 would receive 30,000 ADA.
So the corrected statement would be:
Now if we query payment2.addr we will have a new UTxO containing 500.000.000 Lovelace (500 ADA)