### PR TITLE
add note on saturation levels for slot leader elections

### DIFF
--- a/content/03-new-to-cardano/05-cardano-nodes.mdx
+++ b/content/03-new-to-cardano/05-cardano-nodes.mdx
@@ -52,7 +52,10 @@ aggregated stake of their owners and other stakeholders, also known as
 *delegators*. Slot leaders are randomly elected from among the stake pools. The
 more stake a pool controls, the greater the chance it has of being elected as
 a slot leader to produce a new block that is accepted into the blockchain. This
-is the basic concept of proof of stake (PoS).
+is the basic concept of proof of stake (PoS). To maintain a level playing field, 
+Cardano includes an algorithmic saturation check that prevents any one pool from
+receiving a disproportionately large share of stake rewards simply because it
+controls the most ADA.
 
 **Transaction validation**
 


### PR DESCRIPTION
I'd like to add this update to the Intro docs as I think it's an important note to make about the relative "fairness" of Cardano's PoS implementation. This can address one criticism of PoS where someone argues that it's just about the "rich getting richer"