### PR TITLE
Fix links to CDDL, and add link to Alonzo CDDL

### DIFF
--- a/content/06-cardano-components/10-cardano-serialization-lib.mdx
+++ b/content/06-cardano-components/10-cardano-serialization-lib.mdx
@@ -28,9 +28,10 @@ If you are looking for legacy bindings, you can find them at:
 
 You can find original [CDDL](https://cbor.io/tools.html) specifications at:
 
-+ Byron: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/byron/cddl-spec)
-+ Shelley: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files)
-+ Mary: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/shelley-ma/shelley-ma-test/cddl-files)
++ Byron: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/byron/cddl-spec)
++ Shelley: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files)
++ Mary: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/shelley-ma/shelley-ma-test/cddl-files)
++ Alonzo: [link](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/alonzo/test-suite/cddl-files)
 
 ## Instructions
 

--- a/content/06-cardano-components/10-cardano-serialization-lib.mdx
+++ b/content/06-cardano-components/10-cardano-serialization-lib.mdx
@@ -29,8 +29,8 @@ If you are looking for legacy bindings, you can find them at:
 You can find original [CDDL](https://cbor.io/tools.html) specifications at:
 
 + Byron: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/byron/cddl-spec)
-+ Shelley: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/shelley/chain-and-ledger/shelley-spec-ledger-test/cddl-files)
-+ Mary: [link](https://github.com/input-output-hk/cardano-ledger-specs/tree/master/eras/shelley-ma/shelley-ma-test/cddl-files)
++ Shelley: [link](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley/test-suite/cddl-files/shelley.cddl)
++ Mary: [link](https://github.com/input-output-hk/cardano-ledger/blob/master/eras/shelley-ma/test-suite/cddl-files/shelley-ma.cddl)
 + Alonzo: [link](https://github.com/input-output-hk/cardano-ledger/tree/master/eras/alonzo/test-suite/cddl-files)
 
 ## Instructions


### PR DESCRIPTION
CDDL files were moved around in this commit: https://github.com/input-output-hk/cardano-ledger/commit/9537ad1a93383aa531c1012c46523fc9d972f47b