### PR TITLE
Fix dead concurrency links

### DIFF
--- a/content/10-plutus/10-concurrency.mdx
+++ b/content/10-plutus/10-concurrency.mdx
@@ -37,7 +37,7 @@ should split up their on-chain state across many UTXOs. This will increase the
 concurrency in their application, thereby allowing higher throughput.
 
 To learn more about scalability, you can read
-[how to design a scalable Plutus application](https://plutus.readthedocs.io/en/latest/plutus/howtos/writing-a-scalable-app.html)
+[how to design a scalable Plutus application](https://playground.plutus.iohkdev.io/doc/plutus/howtos/writing-a-scalable-app.html)
 and to learn more about how to organise DApps on Cardano using patterns, read
 the
-[order book pattern](https://plutus.readthedocs.io/en/latest/plutus/explanations/order-book-pattern.html).
+[order book pattern](https://playground.plutus.iohkdev.io/doc/plutus/explanations/order-book-pattern.html).


### PR DESCRIPTION
Guides have moved to playground.plutus.iohkdev.io from plutus.readthedocs.io