### PR TITLE
Remove section hyperlinks

### DIFF
--- a/content/06-cardano-components/05-cardano-db-sync/05-big-query.mdx
+++ b/content/06-cardano-components/05-cardano-db-sync/05-big-query.mdx
@@ -73,7 +73,9 @@ Usually, the cost is $5 per terabyte (TB) of the data queried. Find more informa
 > **Note** that Cardano data tables are divided by epoch numbers so that queries can be made according to the epoch of choice, incurring less costs.
 
 ## Query table schemas
-The
+
+The following tables are available in the dataset:
+
 1.  Table: block
 2.  Table: block_hash
 3.  Table: collateral

--- a/content/06-cardano-components/05-cardano-db-sync/05-big-query.mdx
+++ b/content/06-cardano-components/05-cardano-db-sync/05-big-query.mdx
@@ -73,35 +73,33 @@ Usually, the cost is $5 per terabyte (TB) of the data queried. Find more informa
 > **Note** that Cardano data tables are divided by epoch numbers so that queries can be made according to the epoch of choice, incurring less costs.
 
 ## Query table schemas
-
-The following tables are available in the dataset:
-
-1.  Table: [block](#1-Table-block)
-2.  Table: [block_hash](#2-Table-block_hash)
-3.  Table: [collateral](#3-Table-collateral)
-4.  Table: [cost_model](#4-Table-cost_model)
-5.  Table: [delegation](#5-Table-delegation)
-6.  Table: [epoch_param](#6-Table-epoch_param)
-7.  Table: [ma_minting](#7-Table-ma_minting)
-8.  Table: [meta](#8-Table-meta)
-9.  Table: [param_proposal](#9-Table-param_proposal)
-10. Table: [pool_offline_data](#10-Table-pool_offline_data)
-11. Table: [pool_owner](#11-Table-pool_owner)
-12. Table: [pool_retire](#12-Table-pool_retire)
-13. Table: [pool_update](#13-Table-pool_update)
-14. Table: [redeemer](#14-Table-redeemer)
-15. Table: [rel_addr_txout](#15-Table-rel_addr_txout)
-16. Table: [rel_stake_txout](#16-Table-rel_stake_txout)
-17. Table: [reward](#17-Table-reward)
-18. Table: [schema_version](#18-Table-schema_version)
-19. Table: [script](#19-Table-script)
-20. Table: [stake_registration](#20-Table-stake_registration)
-21. Table: [tx](#21-Table-tx)
-22. Table: [tx_consumed_output](#22-Table-tx_consumed_output)
-23. Table: [tx_hash](#23-Table-tx_hash)
-24. Table: [tx_in_out](#24-Table-tx_in_out)
-25. Table: [tx_metadata](#25-Table-tx_metadata)
-26. Table: [withdrawal](#26-Table-withdrawal)
+The
+1.  Table: block
+2.  Table: block_hash
+3.  Table: collateral
+4.  Table: cost_model
+5.  Table: delegation
+6.  Table: epoch_param
+7.  Table: ma_minting
+8.  Table: meta
+9.  Table: param_proposal
+10. Table: pool_offline_data
+11. Table: pool_owner
+12. Table: pool_retire
+13. Table: pool_update
+14. Table: redeemer
+15. Table: rel_addr_txout
+16. Table: rel_stake_txout
+17. Table: reward
+18. Table: schema_version
+19. Table: script
+20. Table: stake_registration
+21. Table: tx
+22. Table: tx_consumed_output
+23. Table: tx_hash
+24. Table: tx_in_out
+25. Table: tx_metadata
+26. Table: withdrawal
 
 ![](https://ucarecdn.com/d8ba0e26-a9f8-4c0b-be95-94a4d93a5dc4/)
 


### PR DESCRIPTION
Since the hyperlinks are not working in the cardanodocs version of the documentation, we removed them completely to avoid confusion.