### PR TITLE
Update 08-types-of-wallets.mdx

### DIFF
--- a/content/03-new-to-cardano/08-types-of-wallets.mdx
+++ b/content/03-new-to-cardano/08-types-of-wallets.mdx
@@ -98,8 +98,8 @@ Here is a list of hardware wallets to consider for storing and transacting with
 ada:
 
 1.  Trezor Model T
-2.  Ledger Nano S
-3.  Ledger Nano X
+2.  [Ledger Nano S Plus](https://shop.ledger.com/pages/ledger-nano-s-plus)  
+3.  [Ledger Nano X](https://shop.ledger.com/pages/ledger-nano-x)
 
 See
 [how to use hardware wallets with Daedalus.](https://iohk.zendesk.com/hc/en-us/articles/900004722083-How-to-use-Ledger-and-Trezor-HW-with-Daedalus)


### PR DESCRIPTION
Ledger Nano S is not sold anymore, and replaced by the Ledger Nano S Plus.