### PR TITLE
Fixed "Ouroboros protocol" link in cardano-node.mdx

### DIFF
--- a/content/03-learn/02-cardano-node.mdx
+++ b/content/03-learn/02-cardano-node.mdx
@@ -8,7 +8,7 @@ you to participate in the [Cardano](https://cardano.org/) decentralized blockcha
 blockchain network is just a collection of interconnected nodes, all working
 together to validate transactions and blocks by means of consensus. The
 definition of consensus for any given network varies, but for the Cardano
-network it is defined by the [Ouroboros protocol](https://docs.cardano.org/core-concepts/ouroboros-overview). By running a Cardano node, you
+network it is defined by the [Ouroboros protocol](https://docs.cardano.org/learn/ouroboros-overview). By running a Cardano node, you
 are participating in and contributing to the network.
 
 This [cardano-node](https://github.com/input-output-hk/cardano-node) is the top


### PR DESCRIPTION
**Ouroboros protocol** link from [Cardano node](https://docs.cardano.org/learn/cardano-node) page redirects to non existing page. Fixed the link so that it will redirect to [Ouroboros protocol](https://docs.cardano.org/learn/ouroboros-overview) page.