### PR TITLE
Update 01-installing-the-cardano-node.mdx

### DIFF
--- a/content/06-development-guidelines/01-installing-the-cardano-node.mdx
+++ b/content/06-development-guidelines/01-installing-the-cardano-node.mdx
@@ -36,7 +36,7 @@ There is also a Docker image available that you can use.
 
 ``docker image pull inputoutput/cardano-node:<TAG>``
 
-where `<TAG>` is the tag for the version that you require (e.g. `latest` for the most recent stable version, or `1.27.0` for node version 1.27.0).
+where `<TAG>` is the tag for the version that you require (e.g. `latest` for the most recent stable version, or `1.35.3` for node version 1.35.3).
 
 2. Create local `cardano-node-data` and `cardano-node-ipc` volumes:
 


### PR DESCRIPTION
New version for the docker tag used. The docker tutorial still works, though it is using the legacy testnet FYI.