### PR TITLE
BigQuery: new schema browser

### DIFF
--- a/content/07-cardano-components/05-cardano-db-sync/05-big-query.mdx
+++ b/content/07-cardano-components/05-cardano-db-sync/05-big-query.mdx
@@ -98,7 +98,7 @@ information by visiting the
 
 ## Query table schemas
 
-Access the maintained [Cardano on BigQuery - data schema browser](https://docs.google.com/spreadsheets/d/1NJQj8afQ6y1eV6o-mClaNA5-bdViU9c71yw5xVjAmCU/edit?usp=sharing).
+Access the maintained [Cardano on BigQuery - data schema browser](https://datastudio.google.com/reporting/0d60645a-95dd-4531-b85d-7b811fadc351).
 
 The following tables are available in the dataset:
 


### PR DESCRIPTION
the schema browser has been replaced with a Data Studio dashboard.
@olgahryniuk 