### PR TITLE
SCP-4729 Added link to new index of Marlowe developer documentation.

### DIFF
--- a/content/10-marlowe/10-marlowe-resources.mdx
+++ b/content/10-marlowe/10-marlowe-resources.mdx
@@ -26,6 +26,10 @@ These videos give an overview of the Marlowe playground, a browser-based
 environment for building, simulating, and analysing Marlowe contracts. These
 videos focus on creating contracts in the Blockly visual editor.
 
+[Resources for Developing and Deploying Marlowe Contracts](https://developers.cardano.org/docs/smart-contracts/marlowe/#resources-for-developing-and-deploying-marlowe-contracts)
+
+These links provide the information needed to design Marlowe contracts and deploy them on the Cardano blockchain.
+
 ### Marlowe papers
 
 Marlowe was introduced in

--- a/content/10-marlowe/10-marlowe-resources.mdx
+++ b/content/10-marlowe/10-marlowe-resources.mdx
@@ -26,7 +26,7 @@ These videos give an overview of the Marlowe playground, a browser-based
 environment for building, simulating, and analysing Marlowe contracts. These
 videos focus on creating contracts in the Blockly visual editor.
 
-[Resources for Developing and Deploying Marlowe Contracts](https://developers.cardano.org/docs/smart-contracts/marlowe/#resources-for-developing-and-deploying-marlowe-contracts)
+[Resources for developing and deploying Marlowe contracts](https://developers.cardano.org/docs/smart-contracts/marlowe/#resources-for-developing-and-deploying-marlowe-contracts)
 
 These links provide the information needed to design Marlowe contracts and deploy them on the Cardano blockchain.
 


### PR DESCRIPTION
This addition provides a link to the new documentation index for deploying Marlowe contracts on the Cardano blockchain.