### PR TITLE
Remove link to nativetokens.da.iog.solutions

### DIFF
--- a/content/08-native-tokens/01-learn.mdx
+++ b/content/08-native-tokens/01-learn.mdx
@@ -11,6 +11,8 @@ The native tokens feature extends the existing accounting infrastructure defined
 
 Read more about [native tokens and how they compare to ada and ERC20](https://github.com/input-output-hk/cardano-ledger-specs/blob/master/doc/explanations/features.rst) and watch our [native tokens explainer video](https://www.youtube.com/watch?v=PVqsCXh-V5Y). 
 
+Browse native tokens created on the Cardano blockchain and see their transactions in an interactive dashboard that allows filtering and searching: [Native Tokens Dashboard](https://nativetokens.da.iog.solutions/).
+
 ### Single asset ledgers
 
 Cryptocurrency ledgers that track exactly one type of asset are called single-asset ledgers.

--- a/content/08-native-tokens/01-learn.mdx
+++ b/content/08-native-tokens/01-learn.mdx
@@ -11,8 +11,6 @@ The native tokens feature extends the existing accounting infrastructure defined
 
 Read more about [native tokens and how they compare to ada and ERC20](https://github.com/input-output-hk/cardano-ledger-specs/blob/master/doc/explanations/features.rst) and watch our [native tokens explainer video](https://www.youtube.com/watch?v=PVqsCXh-V5Y). 
 
-Browse native tokens created on the Cardano blockchain and see their transactions in an interactive dashboard that allows filtering and searching: [nativetokens.da.iogservices.io](https://nativetokens.da.iogservices.io/).
-
 ### Single asset ledgers
 
 Cryptocurrency ledgers that track exactly one type of asset are called single-asset ledgers.


### PR DESCRIPTION
Trying to access the link today, it returns a 404. Looking at the  internet archive, it looks to have disappeared sometime around  August 2022.

NB. if there are better replacements, then I haven't been able to find them. The issues with this site extend onto the following pages, platforms:

* https://docs.cardano.org/tools/token-dashboard (which also references a different url: https://nativetokens.da.iog.solutions/)
* https://builtoncardano.com/native-tokens-dashboard (which looks like it needs to be moved into the made on Cardano graveyard)

Folks that don't know about the internet archive can see some remnants of this site here (15 August 2022 snapshot): https://web.archive.org/web/20220815223516/https://nativetokens.da.iogservices.io:443/ 