### PR TITLE
Delete 05-testnet-explorer.mdx

### DIFF
--- a/content/05-cardano-testnet/06-tools/05-testnet-explorer.mdx
+++ b/content/05-cardano-testnet/06-tools/05-testnet-explorer.mdx
@@ -1,9 +1,0 @@
----
-title: Testnet Explorer
-metaTitle: Testnet Explorer
-externalUrl: https://explorer.cardano-testnet.iohkdev.io/en
----
-
-import { OpenInNew } from 'styled-icons/material/OpenInNew'
-
-[<Button primary>View the testnet explorer <OpenInNew /></Button>](https://explorer.cardano-testnet.iohkdev.io/en)


### PR DESCRIPTION
Testnet is now deprecated in favor of preview and pre-production environments