### PR TITLE
ETCM-3500 Change example to proof of concept.

### DIFF
--- a/content/08-cardano-sidechains/01-basics/01-introduction-sidechains.mdx
+++ b/content/08-cardano-sidechains/01-basics/01-introduction-sidechains.mdx
@@ -5,11 +5,11 @@ metaTitle: Introduction to sidechains
 
 A sidechain is simply a blockchain that depends on its main chain and is connected to it. This configuration allows the sidechain to have its own consensus algorithm and features. The sidechain is connected to the main chain through a two-way peg that allows the moving of assets between the chains. The finality of blocks is determined through a consensus mechanism that relies on the security of the main chain.
   
-Input Output Global (IOG) provides a sidechain toolkit that is designed to help developers create custom sidechains for a wide range of use cases. To prove the capability of the toolkit, the example application is the Cardano EVM sidechain. EVM stands for Ethereum virtual machine. The Cardano EVM sidechain is EVM-compatible, which means deploying your Ethereum applications is just a matter of deploying your Solidity code on the sidechain and interacting with it through the Web3 API.
+Input Output Global (IOG) provides a sidechain toolkit that is designed to help developers create custom sidechains for a wide range of use cases. To prove the capability of the toolkit, the proof of concept application is the Cardano EVM sidechain. EVM stands for Ethereum virtual machine. The Cardano EVM sidechain is EVM-compatible, which means deploying your Ethereum applications is just a matter of deploying your Solidity code on the sidechain and interacting with it through the Web3 API.
 
-## What is the example EVM sidechain?
+## What is the proof of concept EVM sidechain?
 
-The example EVM sidechain project is an open-source Cardano sidechain protocol providing a client written in Scala. The EVM sidechain is a *child sidechain*, meaning that its starting, or genesis block, is seeded from the main chain and the child blockchain depends on the main chain. The example EVM sidechain enables anyone to run a sidechain network passive node.
+The proof of concept EVM sidechain is an open-source Cardano sidechain protocol providing a client written in Scala. The EVM sidechain is a *child sidechain*, meaning that its starting, or genesis block, is seeded from the main chain and the child blockchain depends on the main chain. The proof of concept EVM sidechain enables anyone to run a sidechain network passive node.
 
 ## Sidechain advantages
 
@@ -35,7 +35,7 @@ Sidechains can expose the same application program interface (API) as an existin
 
 ## Sidechain design elements
 
-The design of the example EVM sidechain is based on the principles laid out in the [2018 white paper](https://iohk.io/en/research/library/papers/proof-of-stake-sidechains/) 'Proof-of-Stake Sidechains' by Peter Gaži, Aggelos Kiayias, and Dionysis Zindros.  
+The design of the proof of concept EVM sidechain is based on the principles laid out in the [2018 white paper](https://iohk.io/en/research/library/papers/proof-of-stake-sidechains/) 'Proof-of-Stake Sidechains' by Peter Gaži, Aggelos Kiayias, and Dionysis Zindros.  
 
 Here are some design features of the Cardano EVM sidechain relevant to Solidity developers.
 
@@ -45,7 +45,7 @@ The EVM sidechain allows the transfer of assets back and forth between the Carda
 
 ### Consensus protocol
 
-Although the Solidity contract may be intended for a Proof of Work blockchain, the example EVM sidechain  provides a Solidity execution environment that does not require miners, but still serves Ethereum JSON RPC methods, giving the well-known benefits of reduced energy usage, speed, and decentralization.
+Although the Solidity contract may be intended for a Proof of Work blockchain, the proof of concept EVM sidechain  provides a Solidity execution environment that does not require miners, but still serves Ethereum JSON RPC methods, giving the well-known benefits of reduced energy usage, speed, and decentralization.
 
 ### Firewall 
 
@@ -55,7 +55,7 @@ The firewall property ensures that a catastrophic failure in one of the chains, 
 
 A critical consideration in sidechain construction is safeguarding a new sidechain against attack.
 
-The example EVM Sidechain construction features 'merged-staking', which allows main-chain validators who have signaled sidechain awareness to create sidechain blocks without moving any stake to the sidechain. Thus sidechain security can be maintained, given an honest stake majority among the entities that have signaled sidechain awareness. Especially in the bootstrapping stage, these main-chain validators are expected to be a large superset of the set of stakeholders that maintain assets in the sidechain.  
+The proof of concept EVM sidechain construction features 'merged-staking', which allows main-chain validators who have signaled sidechain awareness to create sidechain blocks without moving any stake to the sidechain. Thus sidechain security can be maintained, given an honest stake majority among the entities that have signaled sidechain awareness. Especially in the bootstrapping stage, these main-chain validators are expected to be a large superset of the set of stakeholders that maintain assets in the sidechain.  
 
 ## More information
 

--- a/content/08-cardano-sidechains/01-basics/02-ouroboros-description.mdx
+++ b/content/08-cardano-sidechains/01-basics/02-ouroboros-description.mdx
@@ -4,7 +4,7 @@ metaTitle: About Ouroboros BFT
 ---
 
 # Ouroboros BFT: A simple Byzantine fault tolerant consensus protocol
-Ouroboros, named after the symbol of infinity, is the backbone of the Cardano ecosystem. Ouroboros BFT is the version that is implemented in Cardano's example EVM sidechain. It is a simple, deterministic protocol for ledger consensus that tolerates Byzantine faults.
+Ouroboros, named after the symbol of infinity, is the backbone of the Cardano ecosystem. Ouroboros BFT is the version that is implemented in Cardano's proof of concept EVM sidechain. It is a simple, deterministic protocol for ledger consensus that tolerates Byzantine faults.
 
 ## Background 
 So what is a Byzantine fault? To understand that, we have to go back to 1982, to the [Byzantine generals problem](https://www.microsoft.com/en-us/research/uploads/prod/2016/12/The-Byzantine-Generals-Problem.pdf) paper by Leslie Lamport, Robert Shostak, and Marshall Pease. Imagine a number of generals surrounding a city, unable to communicate with each other except by message. The generals must reach consensus on whether to attack or retreat, even if one or more generals is a traitor. This story is easy to grasp, and it is used as an allegory for the situation in a distributed ledger system where the nodes must reach consensus on the contents of the ledger even if one or more of the participating nodes is offline, faulty, or malicious. Such a node can create a **Byzantine fault**. The problem is easy to grasp but hard to solve. That's where Ouroboros comes in.  

--- a/content/08-cardano-sidechains/01-basics/04-block-explorer.mdx
+++ b/content/08-cardano-sidechains/01-basics/04-block-explorer.mdx
@@ -15,7 +15,7 @@ When you use a block explorer, it will list fields and their contents. This docu
 significance of their contents.
 
 ## Glossary
-These are the field names commonly used in block explorers on the example EVM sidechain.
+These are the field names commonly used in block explorers on the proof of concept EVM sidechain.
 ## General terms
 <dl>
   <p></p><dt>

--- a/content/08-cardano-sidechains/02-sidechain-toolkit/01-mainchain-plutus-scripts.mdx
+++ b/content/08-cardano-sidechains/02-sidechain-toolkit/01-mainchain-plutus-scripts.mdx
@@ -184,10 +184,10 @@ A minting policy verifies the following:
 
 - `MPTRootToken` with the name of the Merkle root of the transaction (calculated from from the proof) can be found in the `MPTRootTokenValidator` script address
 - recipient, amount, index and previousMerkleRoot combined with merkleProof match against merkleRootHash
-- `claimTransactionHash` of the transaction is NOT included in the distributed set[^1]
+- `claimTransactionHash` of the transaction is NOT included in the distributed set
 - a new entry with the `claimTransactionHash` of the transaction is created in the distributed set
 - the transaction is signed by the recipient
-- the amount matches the actual tx body contents
+- the amount matches the actual tx body contents.
 
 where the `claimTransactionHash` is a `blake2(cbor(MerkleTreeEntry))`, uniquely identifying a cross-chain transaction by pointing to a Merkle tree and the index of the transaction in the tree.
 

--- a/content/08-cardano-sidechains/03-example-evm-sidechain.mdx
+++ b/content/08-cardano-sidechains/03-example-evm-sidechain.mdx
@@ -1,6 +1,6 @@
 ---
-title: Example EVM Sidechain
-metaTitle: Example EVM Sidechain
+title: Proof of Concept EVM sidechain
+metaTitle: Proof of Concept EVM sidechain
 ---
 
 <!-- heading no content -->

--- a/content/08-cardano-sidechains/03-example-evm-sidechain/00-testnet-disclaimer.mdx
+++ b/content/08-cardano-sidechains/03-example-evm-sidechain/00-testnet-disclaimer.mdx
@@ -3,28 +3,28 @@ title: Testnet disclaimer
 metaTitle: Testnet disclaimer
 ---
 
-By using the example EVM sidechain testnet, you understand the sidechain is in
-development and that use of the example EVM sidechain testnet is entirely at your own
+By using the proof of concept (POC) EVM sidechain testnet, you understand the sidechain is in
+development and that use of the POC EVM sidechain testnet is entirely at your own
 risk.  
 
 You also acknowledge and agree to have an adequate understanding of the risks
-associated with use of the example EVM sidechain testnet and that all information and
+associated with use of the POC EVM sidechain testnet and that all information and
 materials published, distributed or otherwise made available on Cardano Docs is
 provided for non-commercial, personal use, and testing purposes only. This includes
 test currency tokens which have no economic value and are provided only for the purpose of
-testing on the example EVM sidechain testnet.  
+testing on the POC EVM sidechain testnet.  
 
-Example EVM sidechain testnet is available on an ‘AS IS’ and ‘AS AVAILABLE’ basis,
+The POC EVM sidechain testnet is available on an ‘AS IS’ and ‘AS AVAILABLE’ basis,
 without any representations or warranties of any kind. All implied terms are excluded to
 the fullest extent permitted by law. No party involved in, or having contributed to the
-development of, the example EVM sidechain testnet including any of their affiliates,
+development of, the POC EVM sidechain testnet including any of their affiliates,
 directors, employees, contractors, service providers or agents (the parties involved)
 accepts any responsibility or liability to you or any third parties in relation to any materials
-or information accessed via the example EVM sidechain testnet.  
+or information accessed via the POC EVM sidechain testnet.  
 
 You acknowledge and agree that the parties involved are not responsible for any damage
 to your computer systems, loss of data, or any other loss or damage resulting (directly or
-indirectly) from use of the example EVM sidechain testnet.  
+indirectly) from use of the POC EVM sidechain testnet.  
 
 Furthermore, the use of any third-party software tools or products (such as MetaMask,
 Truffle, etc.) is done at your own discretion and with the understanding that you will be

--- a/content/08-cardano-sidechains/03-example-evm-sidechain/01-network-details.mdx
+++ b/content/08-cardano-sidechains/03-example-evm-sidechain/01-network-details.mdx
@@ -3,7 +3,7 @@ title: Network details
 metaTitle: Network details
 ---
 
-The Example EVM sidechain testnet environment consists of two networks:
+The proof of concept EVM sidechain testnet environment consists of two networks:
 
 1. EVM sidechain testnet (sidechain, SC)
 2. A *dedicated* Cardano testnet (main chain, MN)
@@ -17,7 +17,7 @@ The Example EVM sidechain testnet environment consists of two networks:
 
 ## Network utilities
 
-### Example EVM Sidechain
+### EVM Sidechain
 
 |  |  | 
 | --- | :---: |

--- a/content/08-cardano-sidechains/03-example-evm-sidechain/05-sidechain-token.mdx
+++ b/content/08-cardano-sidechains/03-example-evm-sidechain/05-sidechain-token.mdx
@@ -5,7 +5,7 @@ metaTitle: SC_Token and Test ADA
 
 ## What is SC_Token?
 
-**SC_Token<sup>1</sup>** is the native token of the Cardano EVM sidechain Testnet. `SC_Token` can be moved between the main chain (Cardano) and the example EVM sidechain, and `SC_Token` is required to pay for gas. Test `SC_Token` carries no real-world value.
+**SC_Token<sup>1</sup>** is the native token of the Cardano EVM sidechain Testnet. `SC_Token` can be moved between the main chain (Cardano) and the EVM sidechain, and `SC_Token` is required to pay for gas. Test `SC_Token` carries no real-world value.
 
 ### What is gas?
 

--- a/content/08-cardano-sidechains/04-support/01-sidechain-faq.mdx
+++ b/content/08-cardano-sidechains/04-support/01-sidechain-faq.mdx
@@ -17,7 +17,7 @@ Yes, it will be open-sourced under the Input Output Global GitHub repository.
 
 Yes, IOG is working in a less resource-intensive tool. There are other chain indexer tools such as [Oura](https://github.com/txpipe/oura) and [Carp](https://github.com/dcSpark/carp) that could serve the purpose of building a Cardano sidechain.
 
-## The example EVM sidechain application
+## The Proof of Concept EVM sidechain application
 
 These questions relate to the application that IOG built as a proof of concept, using the Cardano Sidechains Toolkit.
 
@@ -27,6 +27,6 @@ They are two separate solutions. [Hydra](https://iohk.io/en/blog/posts/2022/02/0
 
 The EVM sidechain brings Ethereum virtual machine (Solidity-based DApps) execution into Cardano via a sidechain.
 
-### Can you execute a Solidity smart contract on the example EVM sidechain? If this is possible, how do you go between the Ethereum (account model) to the Cardano (EUTXO) accounting model? 
+### Can you execute a Solidity smart contract on the Proof of Concept EVM sidechain? If this is possible, how do you go between the Ethereum (account model) to the Cardano (EUTXO) accounting model? 
 
 The EVM sidechain uses the account model so it is fully compatible with Ethereum-based apps. It doesn't use EUTXO.

--- a/content/08-cardano-sidechains/04-support/01-sidechain-faq.mdx
+++ b/content/08-cardano-sidechains/04-support/01-sidechain-faq.mdx
@@ -3,7 +3,7 @@ title: Sidechains FAQ
 metaTitle:  Sidechains FAQ
 ---
 
-This page answers some frequent questions for the Cardano Sidechains Toolkit and the example EVM sidechain application.
+This page answers some frequent questions for the Cardano Sidechains Toolkit and the proof of concept EVM sidechain application.
 
 ## The Cardano Sidechains Toolkit
 
@@ -17,7 +17,7 @@ Yes, it will be open-sourced under the Input Output Global GitHub repository.
 
 Yes, IOG is working in a less resource-intensive tool. There are other chain indexer tools such as [Oura](https://github.com/txpipe/oura) and [Carp](https://github.com/dcSpark/carp) that could serve the purpose of building a Cardano sidechain.
 
-## The Proof of Concept EVM sidechain application
+## The proof of concept EVM sidechain application
 
 These questions relate to the application that IOG built as a proof of concept, using the Cardano Sidechains Toolkit.
 
@@ -27,6 +27,6 @@ They are two separate solutions. [Hydra](https://iohk.io/en/blog/posts/2022/02/0
 
 The EVM sidechain brings Ethereum virtual machine (Solidity-based DApps) execution into Cardano via a sidechain.
 
-### Can you execute a Solidity smart contract on the Proof of Concept EVM sidechain? If this is possible, how do you go between the Ethereum (account model) to the Cardano (EUTXO) accounting model? 
+### Can you execute a Solidity smart contract on the proof of concept EVM sidechain? If this is possible, how do you go between the Ethereum (account model) to the Cardano (EUTXO) accounting model? 
 
 The EVM sidechain uses the account model so it is fully compatible with Ethereum-based apps. It doesn't use EUTXO.


### PR DESCRIPTION
Used 'proof of concept' in full everywhere except in the testnet disclaimer, where I used POC because of the repetition.