### PR TITLE
fix: strip numbers from canonical URLs

### DIFF
--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -14,6 +14,7 @@ import {
 } from '../components/styles/Docs'
 
 import styled from '@emotion/styled'
+import stripNumbers from '../utils/stripNumbersFromPath'
 
 const forcedNavOrder = config.sidebar.forcedNavOrder
 
@@ -109,7 +110,8 @@ export default class MDXRuntimeTest extends Component {
       config.gatsby.pathPrefix !== '/'
         ? canonicalUrl + config.gatsby.pathPrefix
         : canonicalUrl
-    canonicalUrl = canonicalUrl + mdx.fields.slug
+
+    canonicalUrl = canonicalUrl + stripNumbers(mdx.fields.slug)
 
     return (
       <StyledTemplate useFwTemplate={isFullWidth}>


### PR DESCRIPTION
This PR fixes the broken canonical links on our pages.

The numbers in the slugs are used for sorting in the navigation sidebar and are stripped when the page URL is generated. This change makes it so that the `<link rel="canonical">` tag that's generated for each article also uses this stripped URL rather than the original slug.