### PR TITLE
fix: handle trailing slash throughout website

### DIFF
--- a/src/components/NextPrevious.js
+++ b/src/components/NextPrevious.js
@@ -4,6 +4,7 @@ import Link from './link'
 import { StyledNextPrevious } from './styles/PageNavigationButtons'
 
 import stripNumbers from '../utils/stripNumbersFromPath'
+import { canonicalPath } from '../utils/canonicalUrl'
 
 const NextPrevious = ({ mdx, nav }) => {
   let currentIndex
@@ -15,7 +16,7 @@ const NextPrevious = ({ mdx, nav }) => {
   })
 
   // Strip numbers for .url 's below this point
-  nav.map((el) => {
+  nav.map(el => {
     el.url = stripNumbers(el.url)
   })
 
@@ -61,7 +62,10 @@ const NextPrevious = ({ mdx, nav }) => {
 
   const isPrevLinkParent =
     previousInfo?.url ===
-    nav[currentIndex]?.url?.split('/').slice(0, -1).join('/')
+    nav[currentIndex]?.url
+      ?.split('/')
+      .slice(0, -1)
+      .join('/')
 
   const previousIndexModifier = isPrevLinkParent ? 2 : 1
   const nextIndexModifier = isNextLinkParent ? 2 : 1
@@ -70,7 +74,7 @@ const NextPrevious = ({ mdx, nav }) => {
     <StyledNextPrevious>
       {previousInfo.url && currentIndex >= 0 ? (
         <Link
-          to={nav[currentIndex - previousIndexModifier].url}
+          to={canonicalPath(nav[currentIndex - previousIndexModifier].url)}
           className={'previousBtn'}
         >
           <div className={'leftArrow'}>
@@ -105,7 +109,7 @@ const NextPrevious = ({ mdx, nav }) => {
       ) : null}
       {nextInfo.url && currentIndex >= 0 ? (
         <Link
-          to={nav[currentIndex + nextIndexModifier].url}
+          to={canonicalPath(nav[currentIndex + nextIndexModifier].url)}
           className={'nextBtn'}
         >
           <div className={'nextRightWrapper'}>

--- a/src/components/sidebar/treeNode.js
+++ b/src/components/sidebar/treeNode.js
@@ -6,6 +6,7 @@ import ClosedSvg from '../images/closed'
 import config from '../../../config'
 import Link from '../link'
 import stripNumbers from '../../utils/stripNumbersFromPath'
+import { canonicalUrl, canonicalPath } from '../../utils/canonicalUrl'
 
 const TreeNode = ({
   className = '',
@@ -31,10 +32,7 @@ const TreeNode = ({
   if (typeof document != 'undefined') {
     location = document.location
   }
-  const active =
-    location &&
-    (location.pathname === url ||
-      location.pathname === config.gatsby.pathPrefix + url)
+  const active = location && location.pathname === canonicalPath(url)
 
   const calculatedClassName = `${className} item ${active ? 'active' : ''}`
 
@@ -56,7 +54,7 @@ const TreeNode = ({
             </a>
           )
         : title && (
-            <Link to={externalUrl || url}>
+            <Link to={externalUrl || canonicalPath(url)}>
               {title}
               {externalUrl && <ExternalLink size={14} />}
 

--- a/src/templates/docs.js
+++ b/src/templates/docs.js
@@ -14,7 +14,7 @@ import {
 } from '../components/styles/Docs'
 
 import styled from '@emotion/styled'
-import stripNumbers from '../utils/stripNumbersFromPath'
+import { canonicalUrl } from '../utils/canonicalUrl'
 
 const forcedNavOrder = config.sidebar.forcedNavOrder
 
@@ -104,15 +104,6 @@ export default class MDXRuntimeTest extends Component {
 
     const hasPageHeading = mdx.frontmatter.hasPageHeading
 
-    let canonicalUrl = config.gatsby.siteUrl
-
-    canonicalUrl =
-      config.gatsby.pathPrefix !== '/'
-        ? canonicalUrl + config.gatsby.pathPrefix
-        : canonicalUrl
-
-    canonicalUrl = canonicalUrl + stripNumbers(mdx.fields.slug)
-
     return (
       <StyledTemplate useFwTemplate={isFullWidth}>
         <Layout {...this.props} useFwTemplate={isFullWidth}>
@@ -134,7 +125,7 @@ export default class MDXRuntimeTest extends Component {
             {metaDescription ? (
               <meta property="twitter:description" content={metaDescription} />
             ) : null}
-            <link rel="canonical" href={canonicalUrl} />
+            <link rel="canonical" href={canonicalUrl(mdx.fields.slug)} />
           </Helmet>
 
           <div className={`pageWrap ${isFullWidth ? `fullWidthPage` : ``}`}>

--- a/src/utils/canonicalUrl.js
+++ b/src/utils/canonicalUrl.js
@@ -1,0 +1,30 @@
+const config = require('../../config')
+
+const stripNumbersFromPath = require('./stripNumbersFromPath')
+
+const canonicalPath = path => {
+  let canonical = stripNumbersFromPath(path) ?? '/'
+
+  if (!canonical.startsWith('/')) {
+    canonical = '/' + canonical
+  }
+
+  if (!canonical.endsWith('/') && config.gatsby.trailingSlash) {
+    canonical = canonical + '/'
+  }
+
+  return (config.gatsby.pathPrefix + canonical).replace(/\/+/g, '/')
+}
+
+/**
+ * @param {string} path
+ * @returns {string}
+ */
+const canonicalUrl = path => {
+  return (config.gatsby.siteUrl + canonicalPath(path)).replace(/\/+/g, '/')
+}
+
+module.exports = {
+  canonicalPath,
+  canonicalUrl,
+}

--- a/src/utils/stripNumbersFromPath.js
+++ b/src/utils/stripNumbersFromPath.js
@@ -6,7 +6,7 @@ const stripNumbers = (val) => {
 
   pathsDirectories.map((el) => {
     if (el.length > 0) {
-      pathArray.push(el.substring(3))
+      pathArray.push(el.replace(/[0-9]+-/g, ''))
     }
   })
   return `/${pathArray.join('/')}`


### PR DESCRIPTION
This PR handles `trailingSlash` configuration parameter throughout the whole site.

The codebase is very inconsistent in appending (or not) a trailing slash to internal URLs and Netlify forces all URLs to have a trailing slash anyway. This means the canonical URL from #493 was also invalid (it didn't have a trailing slash) but also that the Next/Previous links as well as the navigation tree are all missing a trailing slash so in effect add an extra redirect to the chain.

This PR hopefully normalizes everything to be trailing-slashed.