### PR TITLE
Add info about faucet's required pool id format - bech32

### DIFF
--- a/content/05-cardano-testnet/06-tools/01-faucet.mdx
+++ b/content/05-cardano-testnet/06-tools/01-faucet.mdx
@@ -15,7 +15,9 @@ ada on the mainnet.
 
 **To request tokens using the faucet:**
 
-1. Enter the address of the account where you want to top up funds.
+1. Select the desired action type:
+   - Enter the address of the account where you want to top up funds.
+   - Enter the pool ID in bech32 format (`pool18ttg8k...a1c`) where you want to delegete funds
 2. If you have been issued with an API key, please enter this to access any
    additional funds you may have been allocated.
 3. Click **Receive test ada**.


### PR DESCRIPTION
When using [faucet](https://docs.cardano.org/cardano-testnet/tools/faucet/) to delegate funds to pool and entering pool ID in `hex` format - `3ad683d9d9f38f43c1b638f0e79f1c91173d324c0c3055971aacf575` there is an error.

```
Request Method: GET
Status Code:400
```
> Request URL:
https://faucet.preview.world.dev.cardano.org/delegate?poolid=3ad683d9d9f38f43c1b638f0e79f1c91173d324c0c3055971aacf575&api_key=&g-recaptcha-response=03AL8dmw-05XFCq0ZZlmR9qg_mIVsjEXrNlxC3VmSAgy8BgEPKXOzrC6tQLaRclR8qPlzfuDXveWykFGJwMG36ogKt0dvmYoYOgClUzsmLR-XU-W6KHDBvXywLgEzZDjkMYCKBADt7_Ddg-VjdKvgliZA26Hs-XhQZ75Y3S29NAY51dhNV6hxZPcTh0r-JxfwxAyNa--1cU31vhrZAdAxhVi9xMCyASbr3lC82XYQRYkDezI1-HRxWqJmHFDE34lzCI6hDpiP7NK0bbi8Yebo5YQDDyfSTA_LFYY1QHYyrGJIh-CUDGEj8JdeVJpnYQMoejWQhUm5Cq7zQkOMBuR1in_APnc7uaySXXyV7F8P5IIYfqYX-eQECE7aRa-HpOWa-wOErKlmMQwGSGrXnXV-kAQi512XZ3qom76ZexMk17ud42c0ofeX5l2XBEOYdjSNFEjYF-KNSuSoaiU4fDPcZdLDmW3jUGD6x0ylLj9HnOQg9NQFR-3eMSjinN6wLyLhWnCoJnB-TRsohe5LkoJin_lMJvMD9QEsbBF9NkAXv-U1KxIr69wAAUmQ

This error however is not present when using `bech32` format for pool ID - e.g. `pool18ttg8kwe7w858sdk8rcw08cujytn6vjvpsc9t9c64n6h27wza2u`.

I ran into this issue when trying to delegate funds to my test pool. 
This PR updates documentation and aims to avoid confusion.

There is an enhancement ticket that is supposed to fix it and support two formats in the future: https://github.com/input-output-hk/cardano-world/issues/95

Original slack thread here: https://input-output-rnd.slack.com/archives/C03NYMJBD7F/p1687265266352119
