### PR TITLE
Update 08-types-of-wallets.mdx, adding NOW Wallet

### DIFF
--- a/content/02-new-to-cardano/08-types-of-wallets.mdx
+++ b/content/02-new-to-cardano/08-types-of-wallets.mdx
@@ -120,4 +120,4 @@ See
 - [SimpleHold Wallet](https://simplehold.io/)
 - [Coin Wallet](https://coin.space/)
 - [NuFi](https://nu.fi/) 
-– [NOW Wallet] (https://walletnow.app)
+– [NOW Wallet](https://walletnow.app)

--- a/content/02-new-to-cardano/08-types-of-wallets.mdx
+++ b/content/02-new-to-cardano/08-types-of-wallets.mdx
@@ -120,3 +120,4 @@ See
 - [SimpleHold Wallet](https://simplehold.io/)
 - [Coin Wallet](https://coin.space/)
 - [NuFi](https://nu.fi/) 
+– [NOW Wallet] (https://walletnow.app)


### PR DESCRIPTION
Hello! NOW Wallet is a non-custodial wallet developed by the ChangeNOW team that allows users to purchase, exchange, store, and stake ADA. 

Both NOW Wallet and ChangeNOW are long-time Cardano supporters and we would greatly appreciate the addition to the types-of-wallets page!