### PR TITLE
Update 10-cardano-addresses.mdx

### DIFF
--- a/docs/03-learn/10-cardano-addresses.mdx
+++ b/docs/03-learn/10-cardano-addresses.mdx
@@ -73,7 +73,8 @@ staking key, they are automatically excluded from the mechanisms that influence
 the slot leadership schedule. Note that using addresses with no stake rights
 effectively decreases the total amount of stake, which plays into the hands of a
 potential adversary.
-Also note that Enterprise addresses may still be used to receive, hold and send  
+
+Also note that enterprise addresses may still be used to receive, hold, and send  
 tokens with a policyID (non-ada assets). 
 
 ### Reward account addresses

--- a/docs/03-learn/10-cardano-addresses.mdx
+++ b/docs/03-learn/10-cardano-addresses.mdx
@@ -73,6 +73,8 @@ staking key, they are automatically excluded from the mechanisms that influence
 the slot leadership schedule. Note that using addresses with no stake rights
 effectively decreases the total amount of stake, which plays into the hands of a
 potential adversary.
+Also note that Enterprise addresses may still be used to receive, hold and send  
+tokens with a policyID (non-ada assets). 
 
 ### Reward account addresses
 


### PR DESCRIPTION
add clarification that enterprise addresses are not ada-only to make it clear that indexing those addresses still requires handling  policyIDs.