### PR TITLE
MK-8267: update terms link

### DIFF
--- a/src/theme/Footer/Layout/index.js
+++ b/src/theme/Footer/Layout/index.js
@@ -30,7 +30,7 @@ export default function FooterLayout({ style, links, logo, copyright }) {
             <li key={'bottom-2'} className="footer__item">
               <FooterLinkItem
                 item={{
-                  href: 'https://static.iohk.io/terms/iohktermsandconditions.pdf',
+                  href: 'https://static.iohk.io/terms/iog-terms-and-conditions.pdf',
                   label: 'IOHK Terms & Conditions',
                 }}
               />


### PR DESCRIPTION
Update the terms and conditions link to keep filenames consistent across all sites. The content is the same on both files.