### PR TITLE
fix dead tutorials links.

### DIFF
--- a/docs/developer-resources/03-transaction-tutorials/index.mdx
+++ b/docs/developer-resources/03-transaction-tutorials/index.mdx
@@ -38,11 +38,11 @@ accessible at https://explorer.cardano.org, for example.
 
 In this section, you will find tutorials on how to create:
 
-- [Minting transactions](https://docs.cardano.org/development-guidelines/transaction-tutorials/minting-transaction/)
-- [Staking transactions](https://docs.cardano.org/development-guidelines/transaction-tutorials/stake-transaction/)
-- [Withdrawing transactions](https://docs.cardano.org/development-guidelines/transaction-tutorials/withdraw-transaction/)
-- [Transactions with funds redelegation](https://docs.cardano.org/development-guidelines/transaction-tutorials/redelegate-transaction/)
-- [Transactions for multiple purposes](https://docs.cardano.org/development-guidelines/transaction-tutorials/multiple-purposes/)
+- [Minting transactions](https://docs.cardano.org/developer-resources/transaction-tutorials/minting-transaction)
+- [Staking transactions](https://docs.cardano.org/developer-resources/transaction-tutorials/stake-transaction)
+- [Withdrawing transactions](https://docs.cardano.org/developer-resources/transaction-tutorials/withdraw-transaction)
+- [Transactions with funds redelegation](https://docs.cardano.org/developer-resources/transaction-tutorials/redelegate-transaction)
+- [Transactions for multiple purposes](https://docs.cardano.org/developer-resources/transaction-tutorials/multiple-purposes)
 
 **For additional references, see**:
 


### PR DESCRIPTION
The links in ## Transaction Tutorials index are all dead. Updated to point to correct links.