### PR TITLE
Add docusaurus-plugin-copy-page-button for AI-assisted dev workflows

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -84,6 +84,7 @@ const config: Config = {
         },
       },
     ],
+    'docusaurus-plugin-copy-page-button',
   ],
 
   presets: [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clsx": "^2.0.0",
     "dayjs": "^1.11.9",
     "docusaurus-node-polyfills": "^1.0.0",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "emotion": "^10.0.23",
     "emotion-server": "^10.0.17",
     "emotion-theming": "^10.0.19",


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Cardano docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Cardano

The plugin is already shipping on most major L1 docs sites: Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, and Chronicle. The pattern is clear: blockchain dev audiences hit AI tools constantly for smart-contract development, infrastructure setup, and tooling questions, and a one-click "page-to-LLM" handoff removes a real friction point.

Cardano docs feel like a strong fit for the same reason. Plutus, the dev portal flow, stake-pool ops — these are exactly the kind of pages devs paste into Claude or ChatGPT to get help with.

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies` in `package.json`
- Adds the plugin to the `plugins` array in `docusaurus.config.ts`

The button auto-injects into the table-of-contents sidebar. No further config required, and it's theme-aware.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button (~10k installs/month)

Happy to revert or adjust if this doesn't fit the project's direction.